### PR TITLE
Add match for `assert_current_path`

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -3,6 +3,8 @@ syntax keyword rubyCapybaraMethod
       \ must_have_css
       \ wont_have_content
       \ wont_have_css
+      \ assert_current_path
+      \ assert_no_current_path
       \ save_screenshot
       \ body
       \ fill_in


### PR DESCRIPTION
Just a little keyword addition.

The method is from SessionMatchers
https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/SessionMatchers